### PR TITLE
Fix global rows variable initialization

### DIFF
--- a/js/sla_calc_browser.js
+++ b/js/sla_calc_browser.js
@@ -1,4 +1,5 @@
 // Simple CSV SLA calculator running fully in-browser
+let rows = [];
 function inferServiceKey(label) {
   const l = label.toLowerCase();
   if (l.includes('load balancer')) return 'alb_nlb';


### PR DESCRIPTION
## Summary
- initialize `rows` globally to avoid reference errors before running the calculator

## Testing
- `node --check js/sla_calc_browser.js`
- `node --check js/sla_data.js`


------
https://chatgpt.com/codex/tasks/task_e_68433aa1428c83258b25564dd2fdfb19