### PR TITLE
Fix sendClaimEmail on page load

### DIFF
--- a/js/sla_calc_browser.js
+++ b/js/sla_calc_browser.js
@@ -1,4 +1,5 @@
 // Simple CSV SLA calculator running fully in-browser
+let rows = [];
 function inferServiceKey(label) {
   const l = label.toLowerCase();
   if (l.includes('load balancer')) return 'alb_nlb';
@@ -94,7 +95,10 @@ async function handleCalculate() {
 window.calculateCredits = handleCalculate;
 
 function sendClaimEmail(){
-  if(!rows.length){alert('Run the calculation first.');return;}
+  if(!rows || !rows.length){
+    alert('Run the calculation first.');
+    return;
+  }
   let body='SLA Credit Request%0D%0A%0D%0A';
   rows.forEach(r=>{
     body+=`${r.service}: ${r.availability}% availability → ${r.credit}% credit%0D%0A`;


### PR DESCRIPTION
## Summary
- define a `rows` variable up front so it's always available
- guard `sendClaimEmail` if the calculation hasn't run

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68433b5cdea88325baefe0d80c100d0b