### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # SimpleScrollSpy
-Simple ScrollSpy example done with pure JavaScript and CS
+Simple ScrollSpy example done with pure JavaScript and CSS
 
-I noticed that many people strugle with scroll spy. Lots of them try to 
-use some existing plugin but in the end get more problems then benefit. 
+I noticed that many people struggle with scroll spy. Lots of them try to 
+use some existing plugin but in the end get more problems than benefit. 
 
 This very simple example probably could be done better, but it will fit 
 its purpose.
 
 ## HTML & CSS
-There are 5 div tags nested in body. Each one has full width and heght of
+There are 5 div tags nested in body. Each one has full width and height of
 screen. Body has auto height with auto overflow so if the content is larger 
-than screen it will get an scroll. There is also nav tag with 5 spans. One 
-as a indicator for each div. They are conected by data attributes. So 
+than screen it will get a scroll. There is also nav tag with 5 spans. One 
+as an indicator for each div. They are connected by data attributes. So 
 span with attribute data-scrollspy-indicator="target2" is indicator for
 div with attribute data-scrollspy-target="target2". 
 
 ## JavaScript.
 Since there is overflow scroll on my body I am attaching event listener on it. 
-On each scroll I am looking at window height and going trough divs
-that cointain data-scrollspy-target attribute. When I find one I am 
-searching for span whos data-scrollspy-indicator attribute values
-is same as this divs data-scrollspy-target attribute value. To that 
+On each scroll I am looking at window height and going through divs
+that contain data-scrollspy-target attribute. When I find one I am 
+searching for span whose data-scrollspy-indicator attribute value
+is the same as this div's data-scrollspy-target attribute value. To that 
 span I am setting class active and removing it from other.
 
 Yes this could be easier to do with jQuery or whatever else in better way. 


### PR DESCRIPTION
## Summary
- fix multiple typographical mistakes in README
- add missing newline at end of README

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68433b5f578c8325b4c0d6f7cd5a04b4