### PR TITLE
Add CloudWatch CSV parser test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,12 @@ If you later add a bundler, add scripts to `package.json`, e.g.
 Then use `npm run dev` for hot reload.
 
 ---
+## 6. Running tests
+Run the unit tests with Node's built-in test runner:
+
+```bash
+node --test
+```
+
+---
 ### Enjoy hacking! 🎉

--- a/js/sla_calc_browser.js
+++ b/js/sla_calc_browser.js
@@ -91,8 +91,6 @@ async function handleCalculate() {
 }
 
 // expose
-window.calculateCredits = handleCalculate;
-
 function sendClaimEmail(){
   if(!rows.length){alert('Run the calculation first.');return;}
   let body='SLA Credit Request%0D%0A%0D%0A';
@@ -104,4 +102,11 @@ function sendClaimEmail(){
   window.location.href=mailto;
 }
 
-window.sendClaimEmail=sendClaimEmail; 
+if (typeof window !== 'undefined') {
+  window.calculateCredits = handleCalculate;
+  window.sendClaimEmail = sendClaimEmail;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { parseCloudWatchCsv };
+}

--- a/test/parseCloudWatchCsv.test.js
+++ b/test/parseCloudWatchCsv.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// require the browser script under a fake window object
+global.window = {};
+const { parseCloudWatchCsv } = require('../js/sla_calc_browser.js');
+
+test('parseCloudWatchCsv splits CSV into blocks', () => {
+  const csv = `MetricName: RequestCount\nNamespace: AWS/ApplicationELB\nStatistic: Sum\nTimestamp,Sum\n2023-01-01 00:00:00,10\n2023-01-01 01:00:00,20\nMetricName: HTTPCode_ELB_5XX_Count\nNamespace: AWS/ApplicationELB\nStatistic: Sum\nTimestamp,Sum\n2023-01-01 00:00:00,1\n2023-01-01 01:00:00,2\n`;
+
+  const blocks = parseCloudWatchCsv(csv);
+  assert.deepStrictEqual(blocks, [
+    {
+      meta: {
+        MetricName: 'RequestCount',
+        Namespace: 'AWS/ApplicationELB',
+        Statistic: 'Sum'
+      },
+      data: 'Timestamp,Sum\n2023-01-01 00:00:00,10\n2023-01-01 01:00:00,20'
+    },
+    {
+      meta: {
+        MetricName: 'HTTPCode_ELB_5XX_Count',
+        Namespace: 'AWS/ApplicationELB',
+        Statistic: 'Sum'
+      },
+      data: 'Timestamp,Sum\n2023-01-01 00:00:00,1\n2023-01-01 01:00:00,2\n'
+    }
+  ]);
+});


### PR DESCRIPTION
## Summary
- export `parseCloudWatchCsv` for Node usage
- test CSV block parsing via Node's built-in `node:test`
- explain running tests in README

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68433b63dc1c8325996d2da1917bafa8