### PR TITLE
Make claim email configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Idea was to make it very simple as an example how it works.
 
 A single-page static tool that helps users export CloudWatch metrics, upload CSVs, and calculate their AWS SLA credits — all in the browser (no backend).
 
+Enter the email address to send the claim to in the results section before clicking **file your claim**.
+
 ---
 ## 1.  Local development on Windows / Linux PC (with hot-reload)
 

--- a/index.html
+++ b/index.html
@@ -64,9 +64,10 @@
 		<section id="email" data-scrollspy-target="email">
 			<h2>results</h2>
 			<p class="subheader">see your calculated availability and applicable credit percentage</p>
-			<table id="results-table" class="instruction-table"></table>
-			<div id="claim-btn" class="box action-box" onclick="sendClaimEmail()">file your claim</div>
-		</section>
+                        <table id="results-table" class="instruction-table"></table>
+                        <input id="claim-email" type="email" class="primary-input" placeholder="you@example.com">
+                        <div id="claim-btn" class="box action-box" onclick="sendClaimEmail()">file your claim</div>
+                </section>
 		<script type="text/javascript" src="scrollspy.js"></script>
 		<script src="js/sla_data.js"></script>
 		<script src="js/sla_calc_browser.js"></script>

--- a/js/sla_calc_browser.js
+++ b/js/sla_calc_browser.js
@@ -97,12 +97,18 @@ function sendClaimEmail(){
     alert('Run the calculation first.');
     return;
   }
+  const emailInput = document.getElementById('claim-email');
+  const to = emailInput?.value.trim();
+  if(!to){
+    alert('Enter a destination email address.');
+    return;
+  }
   let body='SLA Credit Request%0D%0A%0D%0A';
   rows.forEach(r=>{
     body+=`${r.service}: ${r.availability}% availability → ${r.credit}% credit%0D%0A`;
   });
   body+='%0D%0APlease assist with filing an SLA credit request for the services above.';
-  const mailto=`mailto:YOUR_EMAIL@example.com?subject=SLA%20Credit%20Request&body=${body}`;
+  const mailto=`mailto:${encodeURIComponent(to)}?subject=SLA%20Credit%20Request&body=${body}`;
   window.location.href=mailto;
 }
 

--- a/style.css
+++ b/style.css
@@ -371,6 +371,17 @@ body>div {
     background:#444;
 }
 
+.primary-input{
+    margin-top:1em;
+    padding:0.6em 1em;
+    border:1px solid #ccc;
+    border-radius:0.5em;
+    font-family:inherit;
+    font-size:1em;
+    width:230px;
+    box-sizing:border-box;
+}
+
 #claim-btn.box{
     width:230px;
     margin-top:1em;


### PR DESCRIPTION
## Summary
- add email input box for claim destination
- make sendClaimEmail read from input
- style primary input field
- note new step in README

## Testing
- `node --test test/parseCloudWatchCsv.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68437c1f8b6c83259eea713c012a3dbb